### PR TITLE
Support for requeue

### DIFF
--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -282,7 +282,7 @@ handle_frame("SEND", Frame, State) ->
         end);
 
 handle_frame("ACK", Frame, State) ->
-    ack_action("ACK", Frame, State, fun create_ack_method/2);
+    ack_action("ACK", Frame, State, fun create_ack_method/3);
 
 handle_frame("NACK", Frame, State) ->
     ack_action("NACK", Frame, State, fun create_nack_method/3);
@@ -600,6 +600,9 @@ do_send(Destination, _DestHdr,
 create_ack_method(DeliveryTag, #subscription{multi_ack = IsMulti}) ->
     #'basic.ack'{delivery_tag = DeliveryTag,
                  multiple     = IsMulti}.
+
+create_ack_method(DeliveryTag, Subscription, _) ->
+    create_ack_method(DeliveryTag, Subscription).
 
 create_nack_method(DeliveryTag, #subscription{multi_ack = IsMulti}, ReQueue) ->
     #'basic.nack'{delivery_tag = DeliveryTag,


### PR DESCRIPTION
Dead letter exchanges rely heavily on the reject/nack method's requeue header which RabbitMQ-STOMP doesn't seem to support. Here's how I solved it. I haven't got much experience with Erlang, so there's most likely a cleaner solution to the problem.
