### PR TITLE
Terminate STOMP processor when reader exits due to an exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ erl_crash.dump
 /test/certs/
 /test/ebin/test.config
 /tmp/
+/deps/stomppy/

--- a/src/rabbit_stomp_reader.erl
+++ b/src/rabbit_stomp_reader.erl
@@ -74,15 +74,18 @@ go(SupHelperPid, ProcessorPid, Configuration) ->
                             catch _:Ex ->
                                 log_network_error(ConnStr, Ex),
                                 rabbit_net:fast_close(Sock),
+                                rabbit_stomp_processor:flush_and_die(ProcessorPid),
                                 exit(normal)
                             end,
                             done;
                         {error, enotconn} ->
                             rabbit_net:fast_close(Sock0),
+                            rabbit_stomp_processor:flush_and_die(ProcessorPid),
                             exit(normal);
                         {error, Reason} ->
                             log_network_error(ConnStr, Reason),
                             rabbit_net:fast_close(Sock0),
+                            rabbit_stomp_processor:flush_and_die(ProcessorPid),
                             exit(normal)
                         end
             end

--- a/test/src/rabbit_stomp_test.erl
+++ b/test/src/rabbit_stomp_test.erl
@@ -24,16 +24,40 @@
 
 all_tests() ->
     test_messages_not_dropped_on_disconnect(),
+    test_direct_client_connections_are_not_leaked(),
+    ok.
+
+-define(GARBAGE, <<"bdaf63dda9d78b075c748b740e7c3510ad203b07\nbdaf63dd">>).
+
+count_connections() ->
+    length(supervisor2:which_children(rabbit_stomp_client_sup_sup)).
+
+test_direct_client_connections_are_not_leaked() ->
+    N = count_connections(),
+    lists:foreach(fun (_) ->
+                          {ok, Client = {Socket, _}} = rabbit_stomp_client:connect(),
+                          %% send garbage which trips up the parser
+                          gen_tcp:send(Socket, ?GARBAGE),
+                          rabbit_stomp_client:send(
+                           Client, "LOL", [{"", ""}])
+                  end,
+                  lists:seq(1, 1000)),
+    timer:sleep(5000),
+    N = count_connections(),
     ok.
 
 test_messages_not_dropped_on_disconnect() ->
+    N = count_connections(),
     {ok, Client} = rabbit_stomp_client:connect(),
+    N1 = N + 1,
+    N1 = count_connections(),
     [rabbit_stomp_client:send(
        Client, "SEND", [{"destination", ?DESTINATION}],
        [integer_to_list(Count)]) || Count <- lists:seq(1, 1000)],
     rabbit_stomp_client:disconnect(Client),
     QName = rabbit_misc:r(<<"/">>, queue, <<"bulk-test">>),
     timer:sleep(3000),
+    N = count_connections(),
     rabbit_amqqueue:with(
       QName, fun(Q) ->
                      1000 = pget(messages, rabbit_amqqueue:info(Q, [messages]))


### PR DESCRIPTION
Fixes #7.

When we encounter a socket or parsing error, we need to make sure to shoot down processor. Otherwise we leak direct Erlang client connections. Which in turn exposed interesting edge cases such as https://github.com/rabbitmq/rabbitmq-management/issues/29.

Some background on why we fix it in this particular way:

 * We want to avoid "scary" crash reports in the SASL log on network-related exceptions (or even parsing errors).
 * We want to give the processor some time to finish what it's been doing.

So linking won't work.

To test this manually, connect to the server via netcat as explained [in the STOMP plugin documentation](https://www.rabbitmq.com/stomp.html) but after sending a `CONNECT` frame, send some garbage and a few new lines. You will see a parsing error in the log.

For 3.6.0 we will refactor STOMP plugin to only have one process (à la MQTT).