### PR TITLE
Added a newline character at the end of the frame

### DIFF
--- a/src/rabbit_stomp_frame.erl
+++ b/src/rabbit_stomp_frame.erl
@@ -231,7 +231,7 @@ serialize(#stomp_frame{command = Command,
          Len > 0 -> [?HEADER_CONTENT_LENGTH ++ ":", integer_to_list(Len), ?LF];
          true    -> []
      end,
-     ?LF, BodyFragments, 0].
+     ?LF, BodyFragments, 0, ?LF].
 
 serialize_header({K, V}) when is_integer(V) -> hdr(escape(K), integer_to_list(V));
 serialize_header({K, V}) when is_list(V)    -> hdr(escape(K), escape(V)).


### PR DESCRIPTION
PHP treats the NULL character ('\0') as a regular character when reading from the messaging server.
This essentially means that after the stomp plugin responds CONNECTED\n\n\0 the PHP STOMP extension continues to wait for the damned newline character, effectively hanging the application.

Based on the https://stomp.github.io/stomp-specification-1.1.html#Augmented_BNF it seems that there can be a newline at the end of the frame (and even multiple newlines are permitted).