### PR TITLE
Only process the content-length header on the SEND command

### DIFF
--- a/src/rabbit_stomp_frame.erl
+++ b/src/rabbit_stomp_frame.erl
@@ -151,9 +151,11 @@ insert_header(Headers, Name, Value) ->
         false -> [{Name, Value} | Headers]
     end.
 
-parse_body(Content, Frame) ->
-    parse_body(Content, Frame, [],
-               integer_header(Frame, ?HEADER_CONTENT_LENGTH, unknown)).
+parse_body(Content, Frame = #stomp_frame{command = Command}) ->
+    case Command of
+        "SEND" -> parse_body(Content, Frame, [], integer_header(Frame, ?HEADER_CONTENT_LENGTH, unknown));
+        _ -> parse_body(Content, Frame, [], unknown)
+    end.
 
 parse_body(Content, Frame, Chunks, unknown) ->
     parse_body2(Content, Frame, Chunks, case firstnull(Content) of


### PR DESCRIPTION
According to https://stomp.github.io/stomp-specification-1.1.html#Standard_Headers there are three frame types, that can send this header, and only one of them (if I'm not mistaken) is used on the clientside - SEND. It would be great if this header would be ignored for the rest of the client commands.

Specifically, it causes an issue when attempting to ACK a frame that has been previously read in PHP.
Checkout the default code for the stomp extension http://php.net/manual/en/stomp.ack.php. Here is a slightly modified version with a workaround:

```php
<?php

try {
    $client = new Stomp('tcp://localhost:61613', 'guest', 'guest');
} catch(StompException $exception) {
    printf("Connection failed: %s\n", $e->getMessage());
    exit(1);
}

$queue = '/queue/test-queue';
$client->subscribe($queue);


$msg = $client->readFrame();
if ($msg === false) {
    print("No messages available\n");
    exit;
}

// workaround - comment this and you will no longer be able to ACK your messages
// no errors or anything, but the same message will stay in the queue
unset($msg->headers['content-length']);

$client->ack($msg);

$client->unsubscribe($queue);
unset($client);
```

This came up as a problem when migrating from ActiveMQ. Judging from [this issue](https://issues.apache.org/jira/browse/AMQ-3653) they had a similar request a while ago.