### PR TITLE
decreased number of concurrent STOMP connections [fix #31]

### DIFF
--- a/test/src/rabbit_stomp_test.erl
+++ b/test/src/rabbit_stomp_test.erl
@@ -41,7 +41,7 @@ test_direct_client_connections_are_not_leaked() ->
                           rabbit_stomp_client:send(
                            Client, "LOL", [{"", ""}])
                   end,
-                  lists:seq(1, 1000)),
+                  lists:seq(1, 100)),
     timer:sleep(5000),
     N = count_connections(),
     ok.


### PR DESCRIPTION
on OSX default max number of open file is 256 (ulimit -n)