### PR TITLE
Manage duplicate consumer tag error

### DIFF
--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -589,45 +589,56 @@ do_subscribe(Destination, DestHdr, Frame,
                 rabbit_stomp_util:consumer_tag(Frame),
             case Prefetch of
                 undefined -> ok;
-                _         -> amqp_channel:call(
-                               Channel, #'basic.qos'{prefetch_count = Prefetch})
+                _         -> amqp_channel:call(Channel,
+                                               #'basic.qos'{
+                                                  prefetch_count = Prefetch
+                                                 })
             end,
-            ExchangeAndKey = rabbit_routing_util:parse_routing(Destination),
-            try
-                amqp_channel:subscribe(Channel,
-                                       #'basic.consume'{
-                                          queue        = Queue,
-                                          consumer_tag = ConsumerTag,
-                                          no_local     = false,
-                                          no_ack       = (AckMode == auto),
-                                          exclusive    = false,
-                                          arguments    = []},
-                                       self()),
-                ok = rabbit_routing_util:ensure_binding(
-                       Queue, ExchangeAndKey, Channel)
-            catch exit:Err ->
-                    %% it's safe to delete this queue, it was server-named
-                    %% and declared by us
-                    case Destination of
-                        {exchange, _} ->
-                            ok = maybe_clean_up_queue(Queue, State);
-                        {topic, _} ->
-                            ok = maybe_clean_up_queue(Queue, State);
-                        _ ->
-                            ok
+            case dict:find(ConsumerTag, Subs) of
+                {ok, #subscription{ack_mode = AckMode}} ->
+                    send_error("Duplicated ConsumerTag",
+                               "attempt to reuse consumer tag '~s'.",
+                               [ConsumerTag],
+                               State);
+                error ->
+                    ExchangeAndKey =
+                        rabbit_routing_util:parse_routing(Destination),
+                    try
+                        amqp_channel:subscribe(Channel,
+                                               #'basic.consume'{
+                                                  queue        = Queue,
+                                                  consumer_tag = ConsumerTag,
+                                                  no_local     = false,
+                                                  no_ack       = (AckMode == auto),
+                                                  exclusive    = false,
+                                                  arguments    = []},
+                                               self()),
+                        ok = rabbit_routing_util:ensure_binding(
+                               Queue, ExchangeAndKey, Channel)
+                    catch exit:Err ->
+                              %% it's safe to delete this queue, it
+                              %% was server-named and declared by us
+                              case Destination of
+                                  {exchange, _} ->
+                                      ok = maybe_clean_up_queue(Queue, State);
+                                  {topic, _} ->
+                                      ok = maybe_clean_up_queue(Queue, State);
+                                  _ ->
+                                      ok
+                              end,
+                              exit(Err)
                     end,
-                    exit(Err)
-            end,
-            ok(State#state{subscriptions =
-                               dict:store(
-                                 ConsumerTag,
-                                 #subscription{dest_hdr    = DestHdr,
-                                               ack_mode    = AckMode,
-                                               multi_ack   = IsMulti,
-                                               description = Description},
-                                 Subs),
-                           route_state = RouteState1});
-        {error, _} = Err ->
+                    ok(State#state{subscriptions =
+                                   dict:store(
+                                     ConsumerTag,
+                                     #subscription{dest_hdr    = DestHdr,
+                                                   ack_mode    = AckMode,
+                                                   multi_ack   = IsMulti,
+                                                   description = Description},
+                                     Subs),
+                                   route_state = RouteState1})
+            end;
+            {error, _} = Err ->
             Err
     end.
 

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -596,8 +596,8 @@ do_subscribe(Destination, DestHdr, Frame,
             end,
             case dict:find(ConsumerTag, Subs) of
                 {ok, #subscription{ack_mode = AckMode}} ->
-                    Message = "Duplicated ConsumerTag",
-                    Detail = "attempt to reuse consumer tag '~s'.",
+                    Message = "Duplicated subscription identifier",
+                    Detail = "A subscription identified by '~s' alredy exists.",
                     log_error(Message, rabbit_misc:format(Detail, [ConsumerTag]), none),
                     send_error(Message,
                                Detail,

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -595,14 +595,12 @@ do_subscribe(Destination, DestHdr, Frame,
                                                  })
             end,
             case dict:find(ConsumerTag, Subs) of
-                {ok, #subscription{ack_mode = AckMode}} ->
+                {ok, _} ->
                     Message = "Duplicated subscription identifier",
                     Detail = "A subscription identified by '~s' alredy exists.",
-                    log_error(Message, rabbit_misc:format(Detail, [ConsumerTag]), none),
-                    send_error(Message,
-                               Detail,
-                               [ConsumerTag],
-                               State);
+                    error(Message, Detail, [ConsumerTag]),
+                    send_error(Message, Detail, [ConsumerTag], State),
+                    flush_and_die(self());
                 error ->
                     ExchangeAndKey =
                         rabbit_routing_util:parse_routing(Destination),

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -596,8 +596,11 @@ do_subscribe(Destination, DestHdr, Frame,
             end,
             case dict:find(ConsumerTag, Subs) of
                 {ok, #subscription{ack_mode = AckMode}} ->
-                    send_error("Duplicated ConsumerTag",
-                               "attempt to reuse consumer tag '~s'.",
+                    Message = "Duplicated ConsumerTag",
+                    Detail = "attempt to reuse consumer tag '~s'.",
+                    log_error(Message, rabbit_misc:format(Detail, [ConsumerTag]), none),
+                    send_error(Message,
+                               Detail,
                                [ConsumerTag],
                                State);
                 error ->

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -619,26 +619,26 @@ do_subscribe(Destination, DestHdr, Frame,
                         ok = rabbit_routing_util:ensure_binding(
                                Queue, ExchangeAndKey, Channel)
                     catch exit:Err ->
-                              %% it's safe to delete this queue, it
-                              %% was server-named and declared by us
-                              case Destination of
-                                  {exchange, _} ->
-                                      ok = maybe_clean_up_queue(Queue, State);
-                                  {topic, _} ->
-                                      ok = maybe_clean_up_queue(Queue, State);
-                                  _ ->
-                                      ok
-                              end,
-                              exit(Err)
+                        %% it's safe to delete this queue, it
+                        %% was server-named and declared by us
+                        case Destination of
+                            {exchange, _} ->
+                                ok = maybe_clean_up_queue(Queue, State);
+                            {topic, _} ->
+                                ok = maybe_clean_up_queue(Queue, State);
+                            _ ->
+                                ok
+                        end,
+                        exit(Err)
                     end,
                     ok(State#state{subscriptions =
-                                   dict:store(
-                                     ConsumerTag,
-                                     #subscription{dest_hdr    = DestHdr,
-                                                   ack_mode    = AckMode,
-                                                   multi_ack   = IsMulti,
-                                                   description = Description},
-                                     Subs),
+                                       dict:store(
+                                       ConsumerTag,
+                                       #subscription{dest_hdr    = DestHdr,
+                                                     ack_mode    = AckMode,
+                                                     multi_ack   = IsMulti,
+                                                     description = Description},
+                                       Subs),
                                    route_state = RouteState1})
             end;
             {error, _} = Err ->

--- a/test/src/errors.py
+++ b/test/src/errors.py
@@ -23,8 +23,8 @@ class TestErrorsAndCloseConnection(base.BaseTest):
 
         self.assertEquals(1, len(self.listener.errors))
         errorReceived = self.listener.errors[0]
-        self.assertEquals("Duplicated ConsumerTag", errorReceived['headers']['message'])
-        self.assertEquals("attempt to reuse consumer tag 'T_1'.", errorReceived['message'])
+        self.assertEquals("Duplicated subscription identifier", errorReceived['headers']['message'])
+        self.assertEquals("A subscription identified by 'T_1' alredy exists.", errorReceived['message'])
         self.assertFalse(self.conn.is_connected())
 
 class TestErrors(base.BaseTest):


### PR DESCRIPTION
send an ERROR frame, log the error and closes the consumer connection in case of duplicate consumer tag

related to https://github.com/rabbitmq/rabbitmq-stomp/issues/14 & https://github.com/rabbitmq/rabbitmq-stomp/issues/5