### PR TITLE
Manage duplicate subscription ID error

### DIFF
--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -637,7 +637,7 @@ do_subscribe(Destination, DestHdr, Frame,
                                          Subs),
                                    route_state = RouteState1})
             end;
-            {error, _} = Err ->
+        {error, _} = Err ->
             Err
     end.
 

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -589,45 +589,56 @@ do_subscribe(Destination, DestHdr, Frame,
                 rabbit_stomp_util:consumer_tag(Frame),
             case Prefetch of
                 undefined -> ok;
-                _         -> amqp_channel:call(
-                               Channel, #'basic.qos'{prefetch_count = Prefetch})
+                _         -> amqp_channel:call(Channel,
+                                               #'basic.qos'{
+                                                  prefetch_count = Prefetch
+                                                 })
             end,
-            ExchangeAndKey = rabbit_routing_util:parse_routing(Destination),
-            try
-                amqp_channel:subscribe(Channel,
-                                       #'basic.consume'{
-                                          queue        = Queue,
-                                          consumer_tag = ConsumerTag,
-                                          no_local     = false,
-                                          no_ack       = (AckMode == auto),
-                                          exclusive    = false,
-                                          arguments    = []},
-                                       self()),
-                ok = rabbit_routing_util:ensure_binding(
-                       Queue, ExchangeAndKey, Channel)
-            catch exit:Err ->
-                    %% it's safe to delete this queue, it was server-named
-                    %% and declared by us
-                    case Destination of
-                        {exchange, _} ->
-                            ok = maybe_clean_up_queue(Queue, State);
-                        {topic, _} ->
-                            ok = maybe_clean_up_queue(Queue, State);
-                        _ ->
-                            ok
+            case dict:find(ConsumerTag, Subs) of
+                {ok, #subscription{ack_mode = AckMode}} ->
+                    send_error("Duplicated ConsumerTag",
+                               "attempt to reuse consumer tag '~s'.",
+                               [ConsumerTag],
+                               State);
+                error ->
+                    ExchangeAndKey =
+                        rabbit_routing_util:parse_routing(Destination),
+                    try
+                        amqp_channel:subscribe(Channel,
+                                               #'basic.consume'{
+                                                  queue        = Queue,
+                                                  consumer_tag = ConsumerTag,
+                                                  no_local     = false,
+                                                  no_ack       = (AckMode == auto),
+                                                  exclusive    = false,
+                                                  arguments    = []},
+                                               self()),
+                        ok = rabbit_routing_util:ensure_binding(
+                               Queue, ExchangeAndKey, Channel)
+                    catch exit:Err ->
+                              %% it's safe to delete this queue, it
+                              %% was server-named and declared by us
+                              case Destination of
+                                  {exchange, _} ->
+                                      ok = maybe_clean_up_queue(Queue, State);
+                                  {topic, _} ->
+                                      ok = maybe_clean_up_queue(Queue, State);
+                                  _ ->
+                                      ok
+                              end,
+                              exit(Err)
                     end,
-                    exit(Err)
-            end,
-            ok(State#state{subscriptions =
-                               dict:store(
-                                 ConsumerTag,
-                                 #subscription{dest_hdr    = DestHdr,
-                                               ack_mode    = AckMode,
-                                               multi_ack   = IsMulti,
-                                               description = Description},
-                                 Subs),
-                           route_state = RouteState1});
-        {error, _} = Err ->
+                    ok(State#state{subscriptions =
+                                   dict:store(
+                                     ConsumerTag,
+                                     #subscription{dest_hdr    = DestHdr,
+                                                   ack_mode    = AckMode,
+                                                   multi_ack   = IsMulti,
+                                                   description = Description},
+                                     Subs),
+                                   route_state = RouteState1})
+            end;
+            {error, _} = Err ->
             Err
     end.
 

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -589,10 +589,8 @@ do_subscribe(Destination, DestHdr, Frame,
                 rabbit_stomp_util:consumer_tag(Frame),
             case Prefetch of
                 undefined -> ok;
-                _         -> amqp_channel:call(Channel,
-                                               #'basic.qos'{
-                                                  prefetch_count = Prefetch
-                                                 })
+                _         -> amqp_channel:call(
+                               Channel, #'basic.qos'{prefetch_count = Prefetch})
             end,
             case dict:find(ConsumerTag, Subs) of
                 {ok, _} ->
@@ -631,12 +629,12 @@ do_subscribe(Destination, DestHdr, Frame,
                     end,
                     ok(State#state{subscriptions =
                                        dict:store(
-                                       ConsumerTag,
-                                       #subscription{dest_hdr    = DestHdr,
-                                                     ack_mode    = AckMode,
-                                                     multi_ack   = IsMulti,
-                                                     description = Description},
-                                       Subs),
+                                         ConsumerTag,
+                                         #subscription{dest_hdr    = DestHdr,
+                                                       ack_mode    = AckMode,
+                                                       multi_ack   = IsMulti,
+                                                       description = Description},
+                                         Subs),
                                    route_state = RouteState1})
             end;
             {error, _} = Err ->

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -596,8 +596,8 @@ do_subscribe(Destination, DestHdr, Frame,
             end,
             case dict:find(ConsumerTag, Subs) of
                 {ok, #subscription{ack_mode = AckMode}} ->
-                    Message = "Duplicated ConsumerTag",
-                    Detail = "attempt to reuse consumer tag '~s'.",
+                    Message = "Duplicated subscription identifier",
+                    Detail = "A subscription identified by '~s' alredy exists.",
                     log_error(Message, rabbit_misc:format(Detail, [ConsumerTag]), none),
                     send_error(Message,
                                Detail,

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -598,7 +598,7 @@ do_subscribe(Destination, DestHdr, Frame,
                     Detail = "A subscription identified by '~s' alredy exists.",
                     error(Message, Detail, [ConsumerTag]),
                     send_error(Message, Detail, [ConsumerTag], State),
-                    flush_and_die(self());
+                    {stop, normal, close_connection(State)};
                 error ->
                     ExchangeAndKey =
                         rabbit_routing_util:parse_routing(Destination),

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -595,14 +595,12 @@ do_subscribe(Destination, DestHdr, Frame,
                                                  })
             end,
             case dict:find(ConsumerTag, Subs) of
-                {ok, #subscription{ack_mode = AckMode}} ->
+                {ok, _} ->
                     Message = "Duplicated subscription identifier",
                     Detail = "A subscription identified by '~s' alredy exists.",
-                    log_error(Message, rabbit_misc:format(Detail, [ConsumerTag]), none),
-                    send_error(Message,
-                               Detail,
-                               [ConsumerTag],
-                               State);
+                    error(Message, Detail, [ConsumerTag]),
+                    send_error(Message, Detail, [ConsumerTag], State),
+                    flush_and_die(self());
                 error ->
                     ExchangeAndKey =
                         rabbit_routing_util:parse_routing(Destination),

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -596,8 +596,11 @@ do_subscribe(Destination, DestHdr, Frame,
             end,
             case dict:find(ConsumerTag, Subs) of
                 {ok, #subscription{ack_mode = AckMode}} ->
-                    send_error("Duplicated ConsumerTag",
-                               "attempt to reuse consumer tag '~s'.",
+                    Message = "Duplicated ConsumerTag",
+                    Detail = "attempt to reuse consumer tag '~s'.",
+                    log_error(Message, rabbit_misc:format(Detail, [ConsumerTag]), none),
+                    send_error(Message,
+                               Detail,
                                [ConsumerTag],
                                State);
                 error ->

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -615,17 +615,17 @@ do_subscribe(Destination, DestHdr, Frame,
                         ok = rabbit_routing_util:ensure_binding(
                                Queue, ExchangeAndKey, Channel)
                     catch exit:Err ->
-                        %% it's safe to delete this queue, it
-                        %% was server-named and declared by us
-                        case Destination of
-                            {exchange, _} ->
-                                ok = maybe_clean_up_queue(Queue, State);
-                            {topic, _} ->
-                                ok = maybe_clean_up_queue(Queue, State);
-                            _ ->
-                                ok
-                        end,
-                        exit(Err)
+                            %% it's safe to delete this queue, it
+                            %% was server-named and declared by us
+                            case Destination of
+                                {exchange, _} ->
+                                    ok = maybe_clean_up_queue(Queue, State);
+                                {topic, _} ->
+                                    ok = maybe_clean_up_queue(Queue, State);
+                                _ ->
+                                    ok
+                            end,
+                            exit(Err)
                     end,
                     ok(State#state{subscriptions =
                                        dict:store(

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -596,7 +596,7 @@ do_subscribe(Destination, DestHdr, Frame,
                 {ok, _} ->
                     Message = "Duplicated subscription identifier",
                     Detail = "A subscription identified by '~s' alredy exists.",
-                    error(Message, Detail, [ConsumerTag]),
+                    error(Message, Detail, [ConsumerTag], State),
                     send_error(Message, Detail, [ConsumerTag], State),
                     {stop, normal, close_connection(State)};
                 error ->

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -619,26 +619,26 @@ do_subscribe(Destination, DestHdr, Frame,
                         ok = rabbit_routing_util:ensure_binding(
                                Queue, ExchangeAndKey, Channel)
                     catch exit:Err ->
-                              %% it's safe to delete this queue, it
-                              %% was server-named and declared by us
-                              case Destination of
-                                  {exchange, _} ->
-                                      ok = maybe_clean_up_queue(Queue, State);
-                                  {topic, _} ->
-                                      ok = maybe_clean_up_queue(Queue, State);
-                                  _ ->
-                                      ok
-                              end,
-                              exit(Err)
+                        %% it's safe to delete this queue, it
+                        %% was server-named and declared by us
+                        case Destination of
+                            {exchange, _} ->
+                                ok = maybe_clean_up_queue(Queue, State);
+                            {topic, _} ->
+                                ok = maybe_clean_up_queue(Queue, State);
+                            _ ->
+                                ok
+                        end,
+                        exit(Err)
                     end,
                     ok(State#state{subscriptions =
-                                   dict:store(
-                                     ConsumerTag,
-                                     #subscription{dest_hdr    = DestHdr,
-                                                   ack_mode    = AckMode,
-                                                   multi_ack   = IsMulti,
-                                                   description = Description},
-                                     Subs),
+                                       dict:store(
+                                       ConsumerTag,
+                                       #subscription{dest_hdr    = DestHdr,
+                                                     ack_mode    = AckMode,
+                                                     multi_ack   = IsMulti,
+                                                     description = Description},
+                                       Subs),
                                    route_state = RouteState1})
             end;
             {error, _} = Err ->

--- a/test/src/errors.py
+++ b/test/src/errors.py
@@ -8,16 +8,10 @@ class TestErrorsAndCloseConnection(base.BaseTest):
         destination = "/exchange/amq.direct/duplicate-consumer-tag-test"
 
         self.subscribe_dest(self.conn, destination, None,
-                            headers={
-                                'id': 1,
-                                'persistent': True,
-                                })
+                            headers = {'id': 1})
 
         self.subscribe_dest(self.conn, destination, None,
-                            headers={
-                                'id': 1,
-                                'persistent': True,
-                                })
+                            headers = {'id': 1})
 
         self.assertTrue(self.listener.await())
 

--- a/test/src/errors.py
+++ b/test/src/errors.py
@@ -23,8 +23,8 @@ class TestErrorsAndCloseConnection(base.BaseTest):
 
         self.assertEquals(1, len(self.listener.errors))
         errorReceived = self.listener.errors[0]
-        self.assertEquals("Duplicated ConsumerTag", errorReceived['headers']['message'])
-        self.assertEquals("attempt to reuse consumer tag 'T_1'.", errorReceived['message'])
+        self.assertEquals("Duplicated subscription identifier", errorReceived['headers']['message'])
+        self.assertEquals("A subscription identified by 'T_1' alredy exists.", errorReceived['message'])
         self.assertFalse(self.conn.is_connected())
 
 class TestErrors(base.BaseTest):

--- a/test/src/errors.py
+++ b/test/src/errors.py
@@ -17,9 +17,10 @@ class TestErrorsAndCloseConnection(base.BaseTest):
         errorReceived = self.listener.errors[0]
         self.assertEquals("Duplicated subscription identifier", errorReceived['headers']['message'])
         self.assertEquals("A subscription identified by 'T_1' alredy exists.", errorReceived['message'])
-        self.assertFalse(self.conn.is_connected())        
-        
-        
+        time.sleep(2)
+        self.assertFalse(self.conn.is_connected())
+
+
     def test_duplicate_consumer_tag_with_transient_destination(self):
         destination = "/exchange/amq.direct/duplicate-consumer-tag-test1"
         self.__test_duplicate_consumer_tag_with_headers(destination, {'id': 1})
@@ -28,7 +29,7 @@ class TestErrorsAndCloseConnection(base.BaseTest):
         destination = "/queue/duplicate-consumer-tag-test2"
         self.__test_duplicate_consumer_tag_with_headers(destination, {'id': 1,
                                                                       'persistent': True})
-        
+
 
 class TestErrors(base.BaseTest):
 

--- a/test/src/errors.py
+++ b/test/src/errors.py
@@ -4,14 +4,12 @@ import base
 import time
 
 class TestErrorsAndCloseConnection(base.BaseTest):
-    def test_duplicate_consumer_tag(self):
-        destination = "/exchange/amq.direct/duplicate-consumer-tag-test"
+    def __test_duplicate_consumer_tag_with_headers(self, destination, headers):
+        self.subscribe_dest(self.conn, destination, None,
+                            headers = headers)
 
         self.subscribe_dest(self.conn, destination, None,
-                            headers = {'id': 1})
-
-        self.subscribe_dest(self.conn, destination, None,
-                            headers = {'id': 1})
+                            headers = headers)
 
         self.assertTrue(self.listener.await())
 
@@ -19,7 +17,18 @@ class TestErrorsAndCloseConnection(base.BaseTest):
         errorReceived = self.listener.errors[0]
         self.assertEquals("Duplicated subscription identifier", errorReceived['headers']['message'])
         self.assertEquals("A subscription identified by 'T_1' alredy exists.", errorReceived['message'])
-        self.assertFalse(self.conn.is_connected())
+        self.assertFalse(self.conn.is_connected())        
+        
+        
+    def test_duplicate_consumer_tag_with_transient_destination(self):
+        destination = "/exchange/amq.direct/duplicate-consumer-tag-test1"
+        self.__test_duplicate_consumer_tag_with_headers(destination, {'id': 1})
+
+    def test_duplicate_consumer_tag_with_durable_destination(self):
+        destination = "/queue/duplicate-consumer-tag-test2"
+        self.__test_duplicate_consumer_tag_with_headers(destination, {'id': 1,
+                                                                      'persistent': True})
+        
 
 class TestErrors(base.BaseTest):
 
@@ -82,4 +91,3 @@ class TestErrors(base.BaseTest):
         self.assertEquals("'" + content + "' is not a valid " +
                               dtype + " destination\n",
                           err['message'])
-


### PR DESCRIPTION
send an ERROR frame, log the error and closes the consumer connection in case of duplicate subscription ID

related to #14 & #5