### PR TITLE
Use rabbit_net:accept_ack instead of ranch:accept_ack

### DIFF
--- a/src/rabbit_stomp_reader.erl
+++ b/src/rabbit_stomp_reader.erl
@@ -49,7 +49,7 @@ start_link(SupHelperPid, ProcessorPid, Ref, Sock, Configuration) ->
 log(Level, Fmt, Args) -> rabbit_log:log(connection, Level, Fmt, Args).
 
 init(SupHelperPid, ProcessorPid, Ref, Sock, Configuration) ->
-    ok = ranch:accept_ack(Ref),
+    rabbit_net:accept_ack(Ref, Sock),
     go(SupHelperPid, ProcessorPid, Sock, Configuration),
     rabbit_stomp_processor:flush_and_die(ProcessorPid).
 


### PR DESCRIPTION
This function includes operations that must be performed by
processes owning sockets.

Part of https://github.com/rabbitmq/rabbitmq-server/issues/446