### PR TITLE
Disable heartbeats when start fun is undefined

### DIFF
--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -964,6 +964,8 @@ perform_transaction_action({Method, Props, BodyFragments}, State) ->
 %% Heartbeat Management
 %%--------------------------------------------------------------------
 
+ensure_heartbeats(_, State = #state{start_heartbeat_fun = undefined}) ->
+    {{0, 0}, State};
 ensure_heartbeats(Heartbeats,
                   State = #state{start_heartbeat_fun = SHF,
                                  send_fun            = RawSendFun}) ->


### PR DESCRIPTION
Allow passing 'undefined' instead of a fun for the start function.
When the processor receives this value, it simply uses 0,0 as the
heartbeat values which disables heartbeats completely and is
reported back to the client properly.

Fix for https://github.com/rabbitmq/rabbitmq-web-stomp/issues/28