### PR TITLE
.gitignore: make absolute paths relative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,20 @@
 .sw?
 .*.sw?
 *.beam
-/.erlang.mk/
-/cover/
-/debug/
-/deps/
-/doc/
-/ebin/
-/logs/
-/plugins/
+.erlang.mk/
+cover/
+debug/
+deps/
+doc/
+ebin/
+logs/
+plugins/
 
-/rabbitmq_stomp.d
+rabbitmq_stomp.d
 
 # Python testsuite.
 *.pyc
-/test/deps/pika/pika/
-/test/deps/pika/pika-git/
-/test/deps/stomppy/stomppy/
-/test/deps/stomppy/stomppy-git/
+test/deps/pika/pika/
+test/deps/pika/pika-git/
+test/deps/stomppy/stomppy/
+test/deps/stomppy/stomppy-git/


### PR DESCRIPTION
When this repo is a dependency of another one, and only the other one `.git`'s folder is used, the absolute paths git-ignoring apply to the parent project too; thus possibly ignoring files from the parent project.
And really, there's no need to make these paths absolute.

Note: relative paths in `.gitignore` apply as if this file was located at `/.gitignore`.