### PR TITLE
Emit connection stats unconditionally

### DIFF
--- a/src/rabbit_stomp_reader.erl
+++ b/src/rabbit_stomp_reader.erl
@@ -345,18 +345,10 @@ emit_stats(State=#reader_state{socket = Sock, state = ConnState, connection = Co
     Infos = [{pid, Conn}, {state, ConnState} | SockInfos],
     rabbit_event:notify(connection_stats, Infos),
     State1 = rabbit_event:reset_stats_timer(State, #reader_state.stats_timer),
-    %% If we emit an event which looks like we are in flow control, it's not a
-    %% good idea for it to be our last even if we go idle. Keep emitting
-    %% events, either we stay busy or we drop out of flow control.
-    case ConnState of
-        flow -> ensure_stats_timer(State1);
-        _    -> State1
-    end.
+    ensure_stats_timer(State1).
 
-ensure_stats_timer(State = #reader_state{state = running}) ->
-    rabbit_event:ensure_stats_timer(State, #reader_state.stats_timer, emit_stats);
-ensure_stats_timer(State) ->
-    State.
+ensure_stats_timer(State = #reader_state{}) ->
+    rabbit_event:ensure_stats_timer(State, #reader_state.stats_timer, emit_stats).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
of connection (flow control) state.

This makes it much easier to reason about flow control
state when looking at the management UI or monitoring tools
that poll HTTP API.
Now that rabbitmq/rabbitmq-management#41 is merged, there are
few arguments against always emitting stats.

Fixes #70.