### PR TITLE
Add a force_default_creds option

### DIFF
--- a/include/rabbit_stomp.hrl
+++ b/include/rabbit_stomp.hrl
@@ -16,6 +16,7 @@
 
 -record(stomp_configuration, {default_login,
                               default_passcode,
+                              force_default_creds = false,
                               implicit_connect,
                               ssl_cert_login}).
 

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -268,6 +268,10 @@ process_connect(Implicit, Frame,
       end,
       State).
 
+creds(_, _, #stomp_configuration{default_login       = DefLogin,
+                                 default_passcode    = DefPasscode,
+                                 force_default_creds = true}) ->
+    {DefLogin, DefPasscode};
 creds(Frame, SSLLoginName,
       #stomp_configuration{default_login    = DefLogin,
                            default_passcode = DefPasscode}) ->


### PR DESCRIPTION
This option forces the use of the default_login and
default_passcode when authenticating the user. It is
necessary for RabbitMQ-Web-STOMP's use_http_auth option.

Part of https://github.com/rabbitmq/rabbitmq-web-stomp/issues/43
