### PR TITLE
Use '/temp-queue' destination instead of '/queue' for temporary-queues

### DIFF
--- a/examples/perl/rabbitmq_stomp_rpc_client.pl
+++ b/examples/perl/rabbitmq_stomp_rpc_client.pl
@@ -4,12 +4,11 @@ use Net::Stomp;
 my $stomp = Net::Stomp->new({hostname=>'localhost', port=>'61613'});
 $stomp->connect({login=>'guest', passcode=>'guest'});
 
-my $private_q_name = "/queue/c-" . time() . "-" . rand();
+my $private_q_name = "/temp-queue/test";
 
-$stomp->subscribe({destination => $private_q_name});
 $stomp->send({destination => '/queue/rabbitmq_stomp_rpc_service',
               'reply-to' => $private_q_name,
               body => "request from $private_q_name"});
-print "Reply: " . $stomp->receive_frame->body;
+print "Reply: " . $stomp->receive_frame->body . "\n";
 
 $stomp->disconnect;


### PR DESCRIPTION
Currently, an example of stomp client `rabbitmq_stomp_rpc_client.pl` uses `/queue` destination to `reply-to` header.

But I think using the destination of `/temp-queue` is suitable than using `/queue` because
- `/temp-queue` accords with this use-case of RPC
- there is no example to use `/temp-queue`

Here is the result of using `/temp-queue` destination.

```bash
user@localhost:~/rabbitmq-stomp/examples/perl$ perl rabbitmq_stomp_rpc_client.pl 
Reply: Got body: request from /temp-queue/test
user@localhost:~/rabbitmq-stomp/examples/perl$ 
```
```bash
user@localhost:~/rabbitmq-stomp/examples/perl$ perl rabbitmq_stomp_rpc_service.pl 
Waiting for request...
Received message, reply_to = /reply-queue/amq.gen-yGAul0LiGSH75USKM_7SfQ
request from /temp-queue/test
Waiting for request...
```