### PR TITLE
Handle channel errors in stomp_reader

### DIFF
--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -189,6 +189,10 @@ handle_exit(Conn, Reason, State = #proc_state{connection = Conn}) ->
     send_error("AMQP connection died", "Reason: ~p", [Reason], State),
     {stop, {conn_died, Reason}, State};
 
+handle_exit(Ch, {shutdown, {server_initiated_close, Code, Explanation}},
+            State = #proc_state{channel = Ch}) ->
+    amqp_death(Code, Explanation, State);
+
 handle_exit(Ch, Reason, State = #proc_state{channel = Ch}) ->
     send_error("AMQP channel died", "Reason: ~p", [Reason], State),
     {stop, {channel_died, Reason}, State};

--- a/test/src/rabbit_stomp_amqqueue_test.erl
+++ b/test/src/rabbit_stomp_amqqueue_test.erl
@@ -67,10 +67,10 @@ test_publish_unauthorized_error(Channel, _Client, Version) ->
     #'queue.declare_ok'{} =
         amqp_channel:call(Channel, #'queue.declare'{queue       = <<"RestrictedQueue">>,
                                                     auto_delete = true}),
-    rabbit_auth_backend_internal:add_user(<<"foo">>, <<"foo">>),
+    rabbit_auth_backend_internal:add_user(<<"user">>, <<"pass">>),
     rabbit_auth_backend_internal:set_permissions(
-        <<"foo">>, <<"/">>, <<"foo">>, <<"foo">>, <<"foo">>),
-    {ok, ClientFoo} = rabbit_stomp_client:connect(Version, "foo", "foo"),
+        <<"user">>, <<"/">>, <<"nothing">>, <<"nothing">>, <<"nothing">>),
+    {ok, ClientFoo} = rabbit_stomp_client:connect(Version, "user", "pass"),
     try
         rabbit_stomp_client:send(
           ClientFoo, "SEND", [{"destination", "/amq/queue/RestrictedQueue"}], ["hello"]),
@@ -81,7 +81,7 @@ test_publish_unauthorized_error(Channel, _Client, Version) ->
         Err
     after 
         rabbit_stomp_client:disconnect(ClientFoo),
-        os:cmd("../rabbit/scripts/rabbitmqctl delete_user foo")
+        rabbit_auth_backend_internal:delete_user(<<"user">>)
     end.    
 
 test_subscribe_error(_Channel, Client, _Version) ->

--- a/test/src/rabbit_stomp_client.erl
+++ b/test/src/rabbit_stomp_client.erl
@@ -23,24 +23,25 @@
 
 -module(rabbit_stomp_client).
 
--export([connect/0, connect/1, disconnect/1, send/2, send/3, send/4, recv/1]).
+-export([connect/0, connect/1, connect/3, disconnect/1, send/2, send/3, send/4, recv/1]).
 
 -include("rabbit_stomp_frame.hrl").
 
 -define(TIMEOUT, 1000). % milliseconds
 
-connect()  -> connect0([]).
-connect(V) -> connect0([{"accept-version", V}]).
+connect()  -> connect0([], "guest", "guest").
+connect(V) -> connect0([{"accept-version", V}], "guest", "guest").
+connect(V, Login, Pass) -> connect0([{"accept-version", V}], Login, Pass).
 
-connect0(Version) ->
+connect0(Version, Login, Pass) ->
     %% The default port is 61613 but it's in the middle of the ephemeral
     %% ports range on many operating systems. Therefore, there is a
     %% chance this port is already in use. Let's use a port close to the
     %% AMQP default port.
     {ok, Sock} = gen_tcp:connect(localhost, 5673, [{active, false}, binary]),
     Client0 = recv_state(Sock),
-    send(Client0, "CONNECT", [{"login", "guest"},
-                              {"passcode", "guest"} | Version]),
+    send(Client0, "CONNECT", [{"login", Login},
+                              {"passcode", Pass} | Version]),
     {#stomp_frame{command = "CONNECTED"}, Client1} = recv(Client0),
     {ok, Client1}.
 


### PR DESCRIPTION
Fixes #76 
Handle channel `{server_initiated_close, Code, Explanation}` errors same way as connection errors.