### PR TITLE
Notify reductions, garbage_collection, recv_oct and send_oct in the core metrics

### DIFF
--- a/include/rabbit_stomp.hrl
+++ b/include/rabbit_stomp.hrl
@@ -21,3 +21,26 @@
                               ssl_cert_login}).
 
 -define(SUPPORTED_VERSIONS, ["1.0", "1.1", "1.2"]).
+
+-define(INFO_ITEMS,
+        [conn_name,
+         connection,
+         connection_state,
+         session_id,
+         channel,
+         version,
+         ssl_cert_login,
+         implicit_connect,
+         default_login,
+         default_passcode,
+         ssl_login_name,
+         peer_addr,
+         host,
+         port,
+         peer_host,
+         peer_port,
+         protocol,
+         channels,
+         channel_max,
+         frame_max,
+         client_properties]).

--- a/src/rabbit_stomp.erl
+++ b/src/rabbit_stomp.erl
@@ -21,6 +21,7 @@
 -behaviour(application).
 -export([start/2, stop/1]).
 -export([parse_default_user/2]).
+-export([list/0]).
 
 -define(DEFAULT_CONFIGURATION,
         #stomp_configuration{
@@ -86,3 +87,11 @@ report_configuration(#stomp_configuration{
     end,
 
     ok.
+
+list() ->
+    [Client
+     || {_, ListSupPid, _, _} <- supervisor2:which_children(rabbit_stomp_sup),
+        {_, RanchSup, supervisor, _} <- supervisor2:which_children(ListSupPid),
+        {ranch_conns_sup, ConnSup, _, _} <- supervisor:which_children(RanchSup),
+        {_, CliSup, _, _} <- supervisor:which_children(ConnSup),
+        {rabbit_stomp_reader, Client, _, _} <- supervisor:which_children(CliSup)].

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -204,7 +204,7 @@ process_request(ProcessFun, State) ->
     process_request(ProcessFun, fun (StateM) -> StateM end, State).
 
 
-process_request(ProcessFun, SuccessFun, State=#proc_state{connection=Conn}) ->
+process_request(ProcessFun, SuccessFun, State) ->
     Res = case catch ProcessFun(State) of
               {'EXIT',
                {{shutdown,
@@ -217,13 +217,13 @@ process_request(ProcessFun, SuccessFun, State=#proc_state{connection=Conn}) ->
                   Result
           end,
     case Res of
-        {ok, Frame, NewState} ->
+        {ok, Frame, NewState = #proc_state{connection = Conn}} ->
             case Frame of
                 none -> ok;
                 _    -> send_frame(Frame, NewState)
             end,
             {ok, SuccessFun(NewState), Conn};
-        {error, Message, Detail, NewState} ->
+        {error, Message, Detail, NewState = #proc_state{connection = Conn}} ->
             {ok, send_error(Message, Detail, NewState), Conn};
         {stop, normal, NewState} ->
             {stop, normal, SuccessFun(NewState)};

--- a/src/rabbit_stomp_reader.erl
+++ b/src/rabbit_stomp_reader.erl
@@ -22,6 +22,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          code_change/3, terminate/2]).
 -export([start_heartbeats/2]).
+-export([info/2]).
 
 -include("rabbit_stomp.hrl").
 -include("rabbit_stomp_frame.hrl").
@@ -52,6 +53,13 @@ start_link(SupHelperPid, Ref, Sock, Configuration) ->
     {ok, Pid}.
 
 log(Level, Fmt, Args) -> rabbit_log:log(connection, Level, Fmt, Args).
+
+info(Pid, InfoItems) ->
+    case InfoItems -- ?INFO_ITEMS of
+        [] ->
+            gen_server2:call(Pid, {info, InfoItems});
+        UnknownItems -> throw({bad_argument, UnknownItems})
+    end.
 
 init([SupHelperPid, Ref, Sock, Configuration]) ->
     process_flag(trap_exit, true),
@@ -93,6 +101,13 @@ init([SupHelperPid, Ref, Sock, Configuration]) ->
     end.
 
 
+handle_call({info, InfoItems}, _From, State) ->
+    Infos = lists:map(
+              fun(InfoItem) ->
+                      {InfoItem, info_internal(InfoItem, State)}
+              end,
+              InfoItems),
+    {reply, Infos, State};
 handle_call(Msg, From, State) ->
     {stop, {stomp_unexpected_call, Msg, From}, State}.
 
@@ -377,6 +392,15 @@ emit_stats(State) ->
 ensure_stats_timer(State = #reader_state{}) ->
     rabbit_event:ensure_stats_timer(State, #reader_state.stats_timer, emit_stats).
 
+%%----------------------------------------------------------------------------
+
+
+processor_state(#reader_state{ processor_state = ProcState }) -> ProcState.
+processor_state(ProcState, #reader_state{} = State) ->
+    State#reader_state{ processor_state = ProcState}.
+
+%%----------------------------------------------------------------------------
+
 infos(Items, State) -> [{Item, info_internal(Item, State)} || Item <- Items].
 
 info_internal(pid, State) -> info_internal(connection, State);
@@ -395,13 +419,11 @@ info_internal(garbage_collection, _State) ->
 info_internal(reductions, _State) ->
     {reductions, Reductions} = erlang:process_info(self(), reductions),
     Reductions;
+info_internal(conn_name, #reader_state{conn_name = Val}) ->
+    rabbit_data_coercion:to_binary(Val);
 info_internal(connection, #reader_state{connection = Val}) ->
     Val;
 info_internal(connection_state, #reader_state{state = Val}) ->
-    Val.
-%%----------------------------------------------------------------------------
-
-
-processor_state(#reader_state{ processor_state = ProcState }) -> ProcState.
-processor_state(ProcState, #reader_state{} = State) ->
-    State#reader_state{ processor_state = ProcState}.
+    Val;
+info_internal(Key, #reader_state{processor_state = ProcState}) ->
+    rabbit_stomp_processor:info(Key, ProcState).

--- a/test/src/rabbit_stomp_client.erl
+++ b/test/src/rabbit_stomp_client.erl
@@ -23,17 +23,18 @@
 
 -module(rabbit_stomp_client).
 
--export([connect/1, connect/2, connect/4, disconnect/1, send/2, send/3, send/4, recv/1]).
+-export([connect/1, connect/2, connect/4, connect/5, disconnect/1, send/2, send/3, send/4, recv/1]).
 
 -include("rabbit_stomp_frame.hrl").
 
 -define(TIMEOUT, 1000). % milliseconds
 
-connect(Port)  -> connect0([], "guest", "guest", Port).
-connect(V, Port) -> connect0([{"accept-version", V}], "guest", "guest", Port).
-connect(V, Login, Pass, Port) -> connect0([{"accept-version", V}], Login, Pass, Port).
+connect(Port)  -> connect0([], "guest", "guest", Port, []).
+connect(V, Port) -> connect0([{"accept-version", V}], "guest", "guest", Port, []).
+connect(V, Login, Pass, Port) -> connect0([{"accept-version", V}], Login, Pass, Port, []).
+connect(V, Login, Pass, Port, Headers) -> connect0([{"accept-version", V}], Login, Pass, Port, Headers).
 
-connect0(Version, Login, Pass, Port) ->
+connect0(Version, Login, Pass, Port, Headers) ->
     %% The default port is 61613 but it's in the middle of the ephemeral
     %% ports range on many operating systems. Therefore, there is a
     %% chance this port is already in use. Let's use a port close to the
@@ -41,7 +42,7 @@ connect0(Version, Login, Pass, Port) ->
     {ok, Sock} = gen_tcp:connect(localhost, Port, [{active, false}, binary]),
     Client0 = recv_state(Sock),
     send(Client0, "CONNECT", [{"login", Login},
-                              {"passcode", Pass} | Version]),
+                              {"passcode", Pass} | Version] ++ Headers),
     {#stomp_frame{command = "CONNECTED"}, Client1} = recv(Client0),
     {ok, Client1}.
 


### PR DESCRIPTION
Backported part of https://github.com/rabbitmq/rabbitmq-stomp/commit/227447fc98b763da8399deabc944a1c59c3d9e45

Fixes the lack of connection pid on the stats (present since pre-3.6.7 releases), which might also cause a memory leak on the stats db.

Closes #102 