### PR TITLE
Add tests demonstrating sending AMQP custom headers to STOMP subscriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ plugins/
 rabbitmq_stomp.d
 
 # Python testsuite.
+.python-version
 *.pyc
 test/python_SUITE_data/deps/pika/pika/
 test/python_SUITE_data/deps/pika/pika-git/

--- a/test/python_SUITE_data/src/amqp_headers.py
+++ b/test/python_SUITE_data/src/amqp_headers.py
@@ -1,0 +1,35 @@
+import pika
+import base
+import os
+
+class TestAmqpHeaders(base.BaseTest):
+    def test_headers_to_stomp(self):
+        self.listener.reset(1)
+        queueName='test-amqp-headers-to-stomp'
+
+        # Set up STOMP subscription
+        self.subscribe_dest(self.conn, '/topic/test', None, headers={'x-queue-name': queueName})
+
+        # Set up AMQP connection
+        amqp_params = pika.ConnectionParameters(host='localhost', port=int(os.environ["AMQP_PORT"]))
+        amqp_conn = pika.BlockingConnection(amqp_params)
+        amqp_chan = amqp_conn.channel()
+
+        # publish a message with headers to the named AMQP queue
+        amqp_headers = { 'x-custom-hdr-1': 'value1',
+                         'x-custom-hdr-2': 'value2',
+                         'custom-hdr-3': 'value3' }
+        amqp_props = pika.BasicProperties(headers=amqp_headers)
+        amqp_chan.basic_publish(exchange='', routing_key=queueName, body='Hello World!', properties=amqp_props)
+
+        # check if we receive the message from the STOMP subscription
+        self.assertTrue(self.listener.await(2), "initial message not received")
+        self.assertEquals(1, len(self.listener.messages))
+        msg = self.listener.messages[0]
+        self.assertEquals('Hello World!', msg['message'])
+        self.assertEquals('value1', msg['headers']['x-custom-hdr-1'])
+        self.assertEquals('value2', msg['headers']['x-custom-hdr-2'])
+        self.assertEquals('value3', msg['headers']['custom-hdr-3'])
+
+        self.conn.disconnect()
+        amqp_conn.close()

--- a/test/python_SUITE_data/src/base.py
+++ b/test/python_SUITE_data/src/base.py
@@ -103,11 +103,11 @@ class BaseTest(unittest.TestCase):
             self.conn.disconnect()
             self.conn.stop()
 
-   def simple_test_send_rec(self, dest, route = None):
+   def simple_test_send_rec(self, dest, headers={}):
         self.listener.reset()
 
         self.subscribe_dest(self.conn, dest, None)
-        self.conn.send(dest, "foo")
+        self.conn.send(dest, "foo", headers=headers)
 
         self.assertTrue(self.listener.await(), "Timeout, no message received")
 
@@ -119,6 +119,7 @@ class BaseTest(unittest.TestCase):
         msg = self.listener.messages[0]
         self.assertEquals("foo", msg['message'])
         self.assertEquals(dest, msg['headers']['destination'])
+        return msg['headers']
 
    def assertListener(self, errMsg, numMsgs=0, numErrs=0, numRcts=0, timeout=10):
         if numMsgs + numErrs + numRcts > 0:

--- a/test/python_SUITE_data/src/lifecycle.py
+++ b/test/python_SUITE_data/src/lifecycle.py
@@ -129,6 +129,18 @@ class TestLifecycle(base.BaseTest):
         self.assertEquals("Invalid header", errorReceived['headers']['message'])
         self.assertEquals("'message-id' is not allowed on 'SEND'.\n", errorReceived['message'])
 
+    def test_send_recv_header(self):
+        ''' Test sending a custom header and receiving it back '''
+        dest = '/queue/custom-header'
+        hdrs = {'x-custom-header-1': 'value1',
+                'x-custom-header-2': 'value2',
+                'custom-header-3': 'value3'}
+        self.listener.reset(1)
+        recv_hdrs = self.simple_test_send_rec(dest, headers=hdrs)
+        self.assertEquals('value1', recv_hdrs['x-custom-header-1'])
+        self.assertEquals('value2', recv_hdrs['x-custom-header-2'])
+        self.assertEquals('value3', recv_hdrs['custom-header-3'])
+
     def test_disconnect(self):
         ''' Test DISCONNECT command'''
         self.conn.disconnect()

--- a/test/python_SUITE_data/src/test.py
+++ b/test/python_SUITE_data/src/test.py
@@ -5,6 +5,7 @@ import test_runner
 if __name__ == '__main__':
     modules = [
         'ack',
+        'amqp_headers',
         'destinations',
         'errors',
         'lifecycle',


### PR DESCRIPTION
Fixes #112 

Added test cases which show sending and receiving custom headers from STOMP -> STOMP as well as AMQP -> STOMP