### PR TITLE
Generate queue names using compat function instead of term_to_binary.

### DIFF
--- a/src/rabbit_stomp_util.erl
+++ b/src/rabbit_stomp_util.erl
@@ -374,7 +374,9 @@ subscription_queue_name(Destination, SubscriptionId, Frame) ->
             %% AMQP queue names. It doesn't need to be secure; we use md5 here
             %% simply as a convenient means to bound the length.
             rabbit_guid:string(
-              erlang:md5(term_to_binary({Destination, SubscriptionId})),
+                erlang:md5(
+                    term_to_binary_compat:string_and_binary_tuple_2_to_binary(
+                        {Destination, SubscriptionId})),
               "stomp-subscription");
         Name ->
             Name

--- a/src/rabbit_stomp_util.erl
+++ b/src/rabbit_stomp_util.erl
@@ -375,7 +375,7 @@ subscription_queue_name(Destination, SubscriptionId, Frame) ->
             %% simply as a convenient means to bound the length.
             rabbit_guid:string(
                 erlang:md5(
-                    term_to_binary_compat:string_and_binary_tuple_2_to_binary(
+                    term_to_binary_compat:term_to_binary_1(
                         {Destination, SubscriptionId})),
               "stomp-subscription");
         Name ->


### PR DESCRIPTION
Fixes #115
Requires rabbitmq/rabbitmq-server#1262

It's unsafe to use `term_to_binary` to generate IDs like queue names,
because it can change in future erlang versions.
We cannot change queue generation algorithm, because queues can be durable
and renaming a queue is non-trivial in RabbtiMQ. So we use the compat function.