### PR TITLE
Erlang/OTP 19.2 is now the minimum supported version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ addons:
       - elixir
       - xsltproc
 otp_release:
-  #- "18.3" # Skip Erlang 18.3 because of regressions in SSL.
-  - "19.0"
-  - "19.1"
-  - "19.2"  
+  - "19.2"
+  - "19.3"
+  - "20.0"  
 
 before_script:
   # The checkout made by Travis is a "detached HEAD" and branches


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#1305.

[#149563549]