### PR TITLE
Use 10 TLS connection acceptors by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ define PROJECT_ENV
 	    {ssl_cert_login, false},
 	    {implicit_connect, false},
 	    {tcp_listeners, [61613]},
-	    {num_tcp_acceptors, 10},
 	    {ssl_listeners, []},
-	    {num_ssl_acceptors, 1},
+	    {num_tcp_acceptors, 10},
+	    {num_ssl_acceptors, 10},
 	    {tcp_listen_options, [{backlog,   128},
 	                          {nodelay,   true}]},
 	    %% see rabbitmq/rabbitmq-stomp#39

--- a/priv/schema/rabbitmq_stomp.schema
+++ b/priv/schema/rabbitmq_stomp.schema
@@ -52,7 +52,7 @@ end}.
 %% and SSL listeners.
 %%
 %% {num_tcp_acceptors, 10},
-%% {num_ssl_acceptors, 1},
+%% {num_ssl_acceptors, 10},
 
 {mapping, "stomp.num_acceptors.ssl", "rabbitmq_stomp.num_ssl_acceptors", [
     {datatype, integer}

--- a/src/rabbit_stomp_sup.erl
+++ b/src/rabbit_stomp_sup.erl
@@ -30,7 +30,7 @@ init([{Listeners, SslListeners0}, Configuration]) ->
         = case SslListeners0 of
               [] -> {none, 0, []};
               _  -> {rabbit_networking:ensure_ssl(),
-                     application:get_env(rabbitmq_stomp, num_ssl_acceptors, 1),
+                     application:get_env(rabbitmq_stomp, num_ssl_acceptors, 10),
                      case rabbit_networking:poodle_check('STOMP') of
                          ok     -> SslListeners0;
                          danger -> []
@@ -51,13 +51,13 @@ tcp_listener_spec([Address, SocketOpts, Configuration, NumAcceptors]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_stomp_listener_sup, Address, SocketOpts,
       transport(stomp), rabbit_stomp_client_sup, Configuration,
-      stomp, NumAcceptors, "STOMP TCP Listener").
+      stomp, NumAcceptors, "STOMP TCP listener").
 
 ssl_listener_spec([Address, SocketOpts, SslOpts, Configuration, NumAcceptors]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_stomp_listener_sup, Address, SocketOpts ++ SslOpts,
       transport('stomp/ssl'), rabbit_stomp_client_sup, Configuration,
-      'stomp/ssl', NumAcceptors, "STOMP SSL Listener").
+      'stomp/ssl', NumAcceptors, "STOMP TLS listener").
 
 transport(Protocol) ->
     ProxyProtocol = application:get_env(rabbitmq_stomp, proxy_protocol, false),


### PR DESCRIPTION
## Proposed Changes

Bumps number of TLS connection acceptors to 10 by default. See rabbitmq/rabbitmq-server#1729
for context.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue rabbitmq/rabbitmq-server#1729)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-server#1729.

[#161136615]