### PR TITLE
New style config: support stomp.tcp_listen_options.*

### DIFF
--- a/priv/schema/rabbitmq_stomp.schema
+++ b/priv/schema/rabbitmq_stomp.schema
@@ -30,6 +30,94 @@ fun(Conf) ->
     end
 end}.
 
+{mapping, "stomp.tcp_listen_options", "rabbitmq_stomp.tcp_listen_options", [
+    {datatype, {enum, [none]}}]}.
+
+{translation, "rabbitmq_stomp.tcp_listen_options",
+fun(Conf) ->
+    case cuttlefish:conf_get("stomp.tcp_listen_options", Conf, undefined) of
+        none -> [];
+        _    -> cuttlefish:invalid("Invalid stomp.tcp_listen_options")
+    end
+end}.
+
+{mapping, "stomp.tcp_listen_options.backlog", "rabbitmq_stomp.tcp_listen_options.backlog", [
+    {datatype, integer}
+]}.
+
+{mapping, "stomp.tcp_listen_options.nodelay", "rabbitmq_stomp.tcp_listen_options.nodelay", [
+    {datatype, {enum, [true, false]}}
+]}.
+
+{mapping, "stomp.tcp_listen_options.buffer", "rabbitmq_stomp.tcp_listen_options.buffer",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.delay_send", "rabbitmq_stomp.tcp_listen_options.delay_send",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "stomp.tcp_listen_options.dontroute", "rabbitmq_stomp.tcp_listen_options.dontroute",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "stomp.tcp_listen_options.exit_on_close", "rabbitmq_stomp.tcp_listen_options.exit_on_close",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "stomp.tcp_listen_options.fd", "rabbitmq_stomp.tcp_listen_options.fd",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.high_msgq_watermark", "rabbitmq_stomp.tcp_listen_options.high_msgq_watermark",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.high_watermark", "rabbitmq_stomp.tcp_listen_options.high_watermark",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.keepalive", "rabbitmq_stomp.tcp_listen_options.keepalive",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "stomp.tcp_listen_options.low_msgq_watermark", "rabbitmq_stomp.tcp_listen_options.low_msgq_watermark",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.low_watermark", "rabbitmq_stomp.tcp_listen_options.low_watermark",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.port", "rabbitmq_stomp.tcp_listen_options.port",
+    [{datatype, integer}, {validators, ["port"]}]}.
+
+{mapping, "stomp.tcp_listen_options.priority", "rabbitmq_stomp.tcp_listen_options.priority",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.recbuf", "rabbitmq_stomp.tcp_listen_options.recbuf",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.send_timeout", "rabbitmq_stomp.tcp_listen_options.send_timeout",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.send_timeout_close", "rabbitmq_stomp.tcp_listen_options.send_timeout_close",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "stomp.tcp_listen_options.sndbuf", "rabbitmq_stomp.tcp_listen_options.sndbuf",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.tos", "rabbitmq_stomp.tcp_listen_options.tos",
+    [{datatype, integer}]}.
+
+{mapping, "stomp.tcp_listen_options.linger.on", "rabbitmq_stomp.tcp_listen_options.linger",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "stomp.tcp_listen_options.linger.timeout", "rabbitmq_stomp.tcp_listen_options.linger",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbitmq_stomp.tcp_listen_options.linger",
+fun(Conf) ->
+    LingerOn = cuttlefish:conf_get("stomp.tcp_listen_options.linger.on", Conf, false),
+    LingerTimeout = cuttlefish:conf_get("stomp.tcp_listen_options.linger.timeout", Conf, 0),
+    {LingerOn, LingerTimeout}
+end}.
+
+
+%%
+%% TLS
+%%
+
 {mapping, "stomp.listeners.ssl", "rabbitmq_stomp.ssl_listeners",[
     {datatype, {enum, [none]}}
 ]}.

--- a/test/config_schema_SUITE_data/rabbitmq_stomp.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_stomp.snippets
@@ -7,6 +7,42 @@
    stomp.listeners.tcp.2 = ::1:61613",
   [{rabbitmq_stomp,[{tcp_listeners,[{"127.0.0.1",61613},{"::1",61613}]}]}],
   [rabbitmq_stomp]},
+
+ {listener_tcp_options,
+  "stomp.listeners.tcp.1 = 127.0.0.1:61613
+   stomp.listeners.tcp.2 = ::1:61613
+
+   stomp.tcp_listen_options.backlog = 2048
+   stomp.tcp_listen_options.recbuf = 8192
+   stomp.tcp_listen_options.sndbuf = 8192
+
+   stomp.tcp_listen_options.keepalive = true
+   stomp.tcp_listen_options.nodelay   = true
+
+   stomp.tcp_listen_options.exit_on_close = true
+
+   stomp.tcp_listen_options.send_timeout = 120
+",
+  [{rabbitmq_stomp,[
+                    {tcp_listeners,[
+                                    {"127.0.0.1",61613},
+                                    {"::1",61613}
+                                   ]}
+                    , {tcp_listen_options, [
+                                            {backlog, 2048},
+                                            {exit_on_close, true},
+
+                                            {recbuf, 8192},
+                                            {sndbuf, 8192},
+
+                                            {send_timeout, 120},
+
+                                            {keepalive, true},
+                                            {nodelay,   true}
+                                           ]}
+                   ]}],
+  [rabbitmq_stomp]},
+
  {ssl,
   "ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
    ssl_options.certfile   = test/config_schema_SUITE_data/certs/cert.pem


### PR DESCRIPTION
## Proposed Changes

This introduces support for a number of `stomp.tcp_listen_options.*` settings in the new
style config format. They mimic `tcp_listen_options.*` available for AMQP 0-9-1 and AMQP 1.0 listeners.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #129)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #129.

[#157922235]
