### PR TITLE
Support x-queue-type argument

### DIFF
--- a/include/rabbit_stomp_headers.hrl
+++ b/include/rabbit_stomp_headers.hrl
@@ -55,6 +55,7 @@
 -define(HEADER_X_MAX_PRIORITY, "x-max-priority").
 -define(HEADER_X_MESSAGE_TTL, "x-message-ttl").
 -define(HEADER_X_QUEUE_NAME, "x-queue-name").
+-define(HEADER_X_QUEUE_TYPE, "x-queue-type").
 
 -define(MESSAGE_ID_SEPARATOR, "@@").
 
@@ -69,7 +70,8 @@
                            ?HEADER_X_MAX_LENGTH,
                            ?HEADER_X_MAX_LENGTH_BYTES,
                            ?HEADER_X_MAX_PRIORITY,
-                           ?HEADER_X_MESSAGE_TTL
+                           ?HEADER_X_MESSAGE_TTL,
+                           ?HEADER_X_QUEUE_TYPE
                           ]).
 
 -define(HEADER_PARAMS, [

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -822,9 +822,15 @@ send_delivery(Delivery = #'basic.deliver'{consumer_tag = ConsumerTag},
                        [ConsumerTag],
                        State)
     end,
-    amqp_channel:notify_received(DeliveryCtx),
+    notify_received(DeliveryCtx),
     NewState.
 
+notify_received(undefined) ->
+  %% no notification for quorum queues
+  ok;
+notify_received(DeliveryCtx) ->
+  %% notification for flow control
+  amqp_channel:notify_received(DeliveryCtx).
 
 send_method(Method, Channel, State) ->
     amqp_channel:call(Channel, Method),

--- a/src/rabbit_stomp_reader.erl
+++ b/src/rabbit_stomp_reader.erl
@@ -158,6 +158,12 @@ handle_info(#'basic.ack'{delivery_tag = Tag, multiple = IsMulti}, State) ->
                                                                  ProcState),
     {noreply, processor_state(NewProcState, State), hibernate};
 handle_info({Delivery = #'basic.deliver'{},
+             Message = #amqp_msg{}},
+             State) ->
+    %% receiving a message from a quorum queue
+    %% no delivery context
+    handle_info({Delivery, Message, undefined}, State);
+handle_info({Delivery = #'basic.deliver'{},
              #amqp_msg{props = Props, payload = Payload},
              DeliveryCtx},
              State) ->

--- a/src/rabbit_stomp_util.erl
+++ b/src/rabbit_stomp_util.erl
@@ -295,7 +295,10 @@ build_argument(?HEADER_X_MAX_PRIORITY, Val) ->
      list_to_integer(string:strip(Val))};
 build_argument(?HEADER_X_MESSAGE_TTL, Val) ->
     {list_to_binary(?HEADER_X_MESSAGE_TTL), long,
-     list_to_integer(string:strip(Val))}.
+     list_to_integer(string:strip(Val))};
+build_argument(?HEADER_X_QUEUE_TYPE, Val) ->
+  {list_to_binary(?HEADER_X_QUEUE_TYPE), longstr,
+    list_to_binary(string:strip(Val))}.
 
 build_params(EndPoint, Headers) ->
     Params = lists:foldl(fun({K, V}, Acc) ->

--- a/test/python_SUITE.erl
+++ b/test/python_SUITE.erl
@@ -61,5 +61,5 @@ run(Config, Test) ->
 
 
 cur_dir() ->
-    {Src, _} = filename:find_src(?MODULE),
+    {ok, Src} = filelib:find_source(?MODULE),
     filename:dirname(Src).

--- a/test/python_SUITE_data/src/test.py
+++ b/test/python_SUITE_data/src/test.py
@@ -16,5 +16,6 @@ if __name__ == '__main__':
         'destinations',
         'redelivered',
         'topic_permissions',
+        'x_queue_type_quorum'
     ]
     test_runner.run_unittests(modules)

--- a/test/python_SUITE_data/src/x_queue_type_quorum.py
+++ b/test/python_SUITE_data/src/x_queue_type_quorum.py
@@ -1,0 +1,45 @@
+import unittest
+import stomp
+import pika
+import base
+import time
+import os
+
+class TestUserGeneratedQueueName(base.BaseTest):
+
+    def test_quorum_queue(self):
+        queueName='my-quorum-queue'
+
+        # subscribe
+        self.subscribe_dest(
+                self.conn,
+                '/topic/quorum-queue-test',
+                None,
+                headers={
+                    'x-queue-name': queueName,
+                    'x-queue-type': 'quorum',
+                    'durable': True,
+                    'auto-delete': False,
+                    'id': 1234
+                }
+                )
+
+        # let the quorum queue some time to start
+        time.sleep(5)
+
+        connection = pika.BlockingConnection(
+                pika.ConnectionParameters( host='127.0.0.1', port=int(os.environ["AMQP_PORT"])))
+        channel = connection.channel()
+
+        # publish a message to the named queue
+        channel.basic_publish(
+                exchange='',
+                routing_key=queueName,
+                body='Hello World!')
+
+        # check if we receive the message from the STOMP subscription
+        self.assertTrue(self.listener.wait(2), "initial message not received")
+        self.assertEquals(1, len(self.listener.messages))
+
+        self.conn.disconnect()
+        connection.close()

--- a/test/python_SUITE_data/src/x_queue_type_quorum.py
+++ b/test/python_SUITE_data/src/x_queue_type_quorum.py
@@ -1,14 +1,13 @@
-import unittest
-import stomp
 import pika
 import base
 import time
 import os
 
+
 class TestUserGeneratedQueueName(base.BaseTest):
 
     def test_quorum_queue(self):
-        queueName='my-quorum-queue'
+        queueName = 'my-quorum-queue'
 
         # subscribe
         self.subscribe_dest(
@@ -28,7 +27,7 @@ class TestUserGeneratedQueueName(base.BaseTest):
         time.sleep(5)
 
         connection = pika.BlockingConnection(
-                pika.ConnectionParameters( host='127.0.0.1', port=int(os.environ["AMQP_PORT"])))
+                pika.ConnectionParameters(host='127.0.0.1', port=int(os.environ["AMQP_PORT"])))
         channel = connection.channel()
 
         # publish a message to the named queue
@@ -38,7 +37,7 @@ class TestUserGeneratedQueueName(base.BaseTest):
                 body='Hello World!')
 
         # check if we receive the message from the STOMP subscription
-        self.assertTrue(self.listener.wait(2), "initial message not received")
+        self.assertTrue(self.listener.wait(5), "initial message not received")
         self.assertEquals(1, len(self.listener.messages))
 
         self.conn.disconnect()


### PR DESCRIPTION
To be able to use quorum queues. Note deliveries from a classic queue
come with a context to inform back the queue about the handling of the
message (credit flow). Deliveries from a quorum queue do have this
context because quorum queues do not use credit flow. So supporting
quorum queues is not just about propagating the type header to AMQP
but needs also to handle both kinds of deliveries.

Fixes #138

(to merge when we know more about the motivation of using QQ with STOMP).