### PR TITLE
Allow controlling nack requeue on plugin level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ define PROJECT_ENV
 	      {passcode, <<"guest">>}]},
 	    {default_vhost, <<"/">>},
 	    {default_topic_exchange, <<"amq.topic">>},
+		{default_nack_requeue, true},
 	    {ssl_cert_login, false},
 	    {implicit_connect, false},
 	    {tcp_listeners, [61613]},

--- a/priv/schema/rabbitmq_stomp.schema
+++ b/priv/schema/rabbitmq_stomp.schema
@@ -219,3 +219,12 @@ end}.
 
 {mapping, "stomp.hide_server_info", "rabbitmq_stomp.hide_server_info",
     [{datatype, {enum, [true, false]}}]}.
+
+%% Whether or not to always requeue the message on nack
+%% If not set then coordinated by the usage of the frame "requeue" header
+%% Useful when you are not fully controlling the STOMP consumer implementation
+%%
+%% {default_nack_requeue, false}
+
+{mapping, "stomp.default_nack_requeue", "rabbitmq_stomp.default_nack_requeue",
+    [{datatype, {enum, [true, false]}}]}.

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -408,7 +408,7 @@ ack_action(Command, Frame,
                 {ok, {ConsumerTag, _SessionId, DeliveryTag}} ->
                     case maps:find(ConsumerTag, Subs) of
                         {ok, Sub} ->
-                            Requeue = rabbit_stomp_frame:boolean_header(Frame, "requeue", true),
+                            Requeue = rabbit_stomp_frame:boolean_header(Frame, "requeue", application:get_env(rabbitmq_stomp, default_nack_requeue, true)),
                             Method = MethodFun(DeliveryTag, Sub, Requeue),
                             case transactional(Frame) of
                                 {yes, Transaction} ->

--- a/src/rabbit_stomp_processor.erl
+++ b/src/rabbit_stomp_processor.erl
@@ -37,7 +37,7 @@
                 adapter_info, send_fun, ssl_login_name, peer_addr,
                 %% see rabbitmq/rabbitmq-stomp#39
                 trailing_lf, auth_mechanism, auth_login,
-                default_topic_exchange}).
+                default_topic_exchange, default_nack_requeue}).
 
 -record(subscription, {dest_hdr, ack_mode, multi_ack, description}).
 
@@ -163,7 +163,8 @@ initial_state(Configuration,
        reply_queues        = #{},
        frame_transformer   = undefined,
        trailing_lf         = application:get_env(rabbitmq_stomp, trailing_lf, true),
-       default_topic_exchange = application:get_env(rabbitmq_stomp, default_topic_exchange, <<"amq.topic">>)}.
+       default_topic_exchange = application:get_env(rabbitmq_stomp, default_topic_exchange, <<"amq.topic">>),
+       default_nack_requeue = application:get_env(rabbitmq_stomp, default_nack_requeue, true)}.
 
 
 command({"STOMP", Frame}, State) ->
@@ -399,8 +400,9 @@ handle_frame(Command, _Frame, State) ->
 
 ack_action(Command, Frame,
            State = #proc_state{subscriptions = Subs,
-                          channel       = Channel,
-                          version       = Version}, MethodFun) ->
+                          channel              = Channel,
+                          version              = Version,
+                          default_nack_requeue = DefaultNackRequeue}, MethodFun) ->
     AckHeader = rabbit_stomp_util:ack_header_name(Version),
     case rabbit_stomp_frame:header(Frame, AckHeader) of
         {ok, AckValue} ->
@@ -408,7 +410,7 @@ ack_action(Command, Frame,
                 {ok, {ConsumerTag, _SessionId, DeliveryTag}} ->
                     case maps:find(ConsumerTag, Subs) of
                         {ok, Sub} ->
-                            Requeue = rabbit_stomp_frame:boolean_header(Frame, "requeue", application:get_env(rabbitmq_stomp, default_nack_requeue, true)),
+                            Requeue = rabbit_stomp_frame:boolean_header(Frame, "requeue", DefaultNackRequeue),
                             Method = MethodFun(DeliveryTag, Sub, Requeue),
                             case transactional(Frame) of
                                 {yes, Transaction} ->


### PR DESCRIPTION
## Proposed Changes

👋

**Why:**
Various companies are using RMQ with third party software which doesn't offer the ability to alter the source code related to how the STOMP consumer behaves on the frame level, e.g. there's no possibility to actually change the frame `requeue` header to `false` as the frame is created by the 3rd party software.

This has proven to be an issue on a project I have been working on as the current stomp plugin frame `requeue` implementation defaults to `true` if the `requeue` header doesn't exist on the frame. The side-effect of this behaviour is that we ended in a loop of massive re-deliveries as the messages were always re-queued, while, what we wanted was to avoid re-queueing.

In order to get around this issue, we decided to expose the `stomp.default_nack_requeue` configuration option which would serve as a default for the `requeue` frame option.

**This PR tries to:**
- retain the existing frame requeue logic and defaults
- add the `stomp.default_nack_requeue` option which overrides the default frame `requeue` value

**Side-effects:**
- no changes will be noticed by the consumers which are setting this on the message level, or not setting at all
- exposes the setting for those who can't use the frame message header but can configure their stomp plugins

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

When running tests locally I get the following errors (regardless whether I'm on this branch or on rabbitmq-stomp master branch):

![image](https://user-images.githubusercontent.com/8964589/77051983-74150180-69cc-11ea-9cbf-68b063604d06.png)

I have been running:

```
make
make check
```

What I can confirm is that the functionality works when the plugin is released with `make dist`.

## TODO
- [ ] Understand why the tests are unable to run
- [ ] Add spec for the newly added config option