### PR TITLE
Maintenance mode event support

### DIFF
--- a/src/rabbit_stomp.erl
+++ b/src/rabbit_stomp.erl
@@ -24,7 +24,8 @@
 -export([connection_info_local/1,
          emit_connection_info_local/3,
          emit_connection_info_all/4,
-         list/0]).
+         list/0,
+         close_all_client_connections/1]).
 
 -define(DEFAULT_CONFIGURATION,
         #stomp_configuration{
@@ -36,10 +37,22 @@
 start(normal, []) ->
     Config = parse_configuration(),
     Listeners = parse_listener_configuration(),
-    rabbit_stomp_sup:start_link(Listeners, Config).
+    Result = rabbit_stomp_sup:start_link(Listeners, Config),
+    EMPid = case rabbit_event:start_link() of
+              {ok, Pid}                       -> Pid;
+              {error, {already_started, Pid}} -> Pid
+            end,
+    gen_event:add_handler(EMPid, rabbit_stomp_internal_event_handler, []),
+    Result.
 
 stop(_) ->
     rabbit_stomp_sup:stop_listeners().
+
+-spec close_all_client_connections(string() | binary()) -> {'ok', non_neg_integer()}.
+close_all_client_connections(Reason) ->
+     Connections = list(),
+    [rabbit_stomp_reader:close_connection(Pid, Reason) || Pid <- Connections],
+    {ok, length(Connections)}.
 
 emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
     Pids = [spawn_link(Node, rabbit_stomp, emit_connection_info_local,

--- a/src/rabbit_stomp.erl
+++ b/src/rabbit_stomp.erl
@@ -38,8 +38,8 @@ start(normal, []) ->
     Listeners = parse_listener_configuration(),
     rabbit_stomp_sup:start_link(Listeners, Config).
 
-stop(_State) ->
-    ok.
+stop(_) ->
+    rabbit_stomp_sup:stop_listeners().
 
 emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
     Pids = [spawn_link(Node, rabbit_stomp, emit_connection_info_local,

--- a/src/rabbit_stomp_internal_event_handler.erl
+++ b/src/rabbit_stomp_internal_event_handler.erl
@@ -1,0 +1,46 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_stomp_internal_event_handler).
+
+-behaviour(gen_event).
+
+-export([init/1, handle_event/2, handle_call/2, handle_info/2, terminate/2, code_change/3]).
+
+-import(rabbit_misc, [pget/2]).
+
+init([]) ->
+  {ok, []}.
+
+handle_event({event, maintenance_connections_closed, _Info, _, _}, State) ->
+  %% we should close our connections
+  {ok, NConnections} = rabbit_stomp:close_all_client_connections("node is being put into maintenance mode"),
+  rabbit_log:alert("Closed ~b local STOMP client connections", [NConnections]),
+  {ok, State};
+handle_event(_Event, State) ->
+  {ok, State}.
+
+handle_call(_Request, State) ->
+  {ok, State}.
+
+handle_info(_Info, State) ->
+  {ok, State}.
+
+terminate(_Reason, _State) ->
+  ok.
+
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.

--- a/src/rabbit_stomp_reader.erl
+++ b/src/rabbit_stomp_reader.erl
@@ -22,7 +22,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          code_change/3, terminate/2]).
 -export([start_heartbeats/2]).
--export([info/2]).
+-export([info/2, close_connection/2]).
 -export([ssl_login_name/2]).
 
 -include("rabbit_stomp.hrl").
@@ -53,6 +53,10 @@ info(Pid, InfoItems) ->
             gen_server2:call(Pid, {info, InfoItems});
         UnknownItems -> throw({bad_argument, UnknownItems})
     end.
+
+close_connection(Pid, Reason) ->
+    gen_server:cast(Pid, {close_connection, Reason}).
+
 
 init([SupHelperPid, Ref, Configuration]) ->
     process_flag(trap_exit, true),
@@ -106,6 +110,8 @@ handle_call({info, InfoItems}, _From, State) ->
 handle_call(Msg, From, State) ->
     {stop, {stomp_unexpected_call, Msg, From}, State}.
 
+handle_cast({close_connection, Reason}, State) ->
+    {stop, {shutdown, {server_initiated_close, Reason}}, State};
 handle_cast(client_timeout, State) ->
     {stop, {shutdown, client_heartbeat_timeout}, State};
 handle_cast(Msg, State) ->
@@ -281,7 +287,7 @@ run_socket(State = #reader_state{socket = Sock}) ->
 terminate(Reason, undefined) ->
     log_reason(Reason, undefined),
     {stop, Reason};
-terminate(Reason, State = #reader_state{ processor_state = ProcState }) ->
+terminate(Reason, State = #reader_state{processor_state = ProcState}) ->
   maybe_emit_stats(State),
   log_reason(Reason, State),
   _ = rabbit_stomp_processor:flush_and_die(ProcState),
@@ -326,19 +332,24 @@ log_reason({network_error, Reason}, _State) ->
 log_reason({shutdown, client_heartbeat_timeout},
            #reader_state{ processor_state = ProcState }) ->
     AdapterName = rabbit_stomp_processor:adapter_name(ProcState),
-    rabbit_log:warning("STOMP detected missed client heartbeat(s) "
-                       "on connection ~s, closing it~n", [AdapterName]);
+    rabbit_log_connection:warning("STOMP detected missed client heartbeat(s) "
+                                  "on connection ~s, closing it~n", [AdapterName]);
 
-log_reason(normal, #reader_state{ conn_name  = ConnName}) ->
+log_reason({shutdown, {server_initiated_close, Reason}},
+           #reader_state{conn_name = ConnName}) ->
+    rabbit_log_connection:info("closing STOMP connection ~p (~s), reason: ~s~n",
+                               [self(), ConnName, Reason]);
+
+log_reason(normal, #reader_state{conn_name  = ConnName}) ->
     rabbit_log_connection:info("closing STOMP connection ~p (~s)~n", [self(), ConnName]);
 
 log_reason(shutdown, undefined) ->
     rabbit_log_connection:error("closing STOMP connection that never completed connection handshake (negotiation)~n", []);
 
-log_reason(Reason, #reader_state{ processor_state = ProcState }) ->
+log_reason(Reason, #reader_state{processor_state = ProcState}) ->
     AdapterName = rabbit_stomp_processor:adapter_name(ProcState),
-    rabbit_log:warning("STOMP connection ~s terminated"
-                       " with reason ~p, closing it~n", [AdapterName, Reason]).
+    rabbit_log_connection:warning("STOMP connection ~s terminated"
+                                  " with reason ~p, closing it~n", [AdapterName, Reason]).
 
 log_tls_alert(handshake_failure, ConnStr) ->
     rabbit_log_connection:error("STOMP detected TLS upgrade error on ~s: handshake failure~n",

--- a/src/rabbit_stomp_sup.erl
+++ b/src/rabbit_stomp_sup.erl
@@ -51,14 +51,8 @@ init([{Listeners, SslListeners0}, Configuration]) ->
                           [SocketOpts, SslOpts, Configuration, NumSslAcceptors], SslListeners)}}.
 
 stop_listeners() ->
-    case rabbit_networking:ranch_ref_of_protocol(?TCP_PROTOCOL) of
-        {error, not_found} -> ok;
-        Ref1               -> ranch:stop_listener(Ref1)
-    end,
-    case rabbit_networking:ranch_ref_of_protocol(?TLS_PROTOCOL) of
-        {error, not_found} -> ok;
-        Ref2               -> ranch:stop_listener(Ref2)
-    end,
+    rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
+    rabbit_networking:stop_ranch_listener_of_protocol(?TLS_PROTOCOL),
     ok.
 
 %%

--- a/src/rabbit_stomp_sup.erl
+++ b/src/rabbit_stomp_sup.erl
@@ -17,7 +17,10 @@
 -module(rabbit_stomp_sup).
 -behaviour(supervisor).
 
--export([start_link/2, init/1]).
+-export([start_link/2, init/1, stop_listeners/0]).
+
+-define(TCP_PROTOCOL, 'stomp').
+-define(TLS_PROTOCOL, 'stomp/ssl').
 
 start_link(Listeners, Configuration) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE,
@@ -47,6 +50,21 @@ init([{Listeners, SslListeners0}, Configuration]) ->
            listener_specs(fun ssl_listener_spec/1,
                           [SocketOpts, SslOpts, Configuration, NumSslAcceptors], SslListeners)}}.
 
+stop_listeners() ->
+    case rabbit_networking:ranch_ref_of_protocol(?TCP_PROTOCOL) of
+        {error, not_found} -> ok;
+        Ref1               -> ranch:stop_listener(Ref1)
+    end,
+    case rabbit_networking:ranch_ref_of_protocol(?TLS_PROTOCOL) of
+        {error, not_found} -> ok;
+        Ref2               -> ranch:stop_listener(Ref2)
+    end,
+    ok.
+
+%%
+%% Implementation
+%%
+
 listener_specs(Fun, Args, Listeners) ->
     [Fun([Address | Args]) ||
         Listener <- Listeners,
@@ -55,17 +73,17 @@ listener_specs(Fun, Args, Listeners) ->
 tcp_listener_spec([Address, SocketOpts, Configuration, NumAcceptors]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_stomp_listener_sup, Address, SocketOpts,
-      transport(stomp), rabbit_stomp_client_sup, Configuration,
+      transport(?TCP_PROTOCOL), rabbit_stomp_client_sup, Configuration,
       stomp, NumAcceptors, "STOMP TCP listener").
 
 ssl_listener_spec([Address, SocketOpts, SslOpts, Configuration, NumAcceptors]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_stomp_listener_sup, Address, SocketOpts ++ SslOpts,
-      transport('stomp/ssl'), rabbit_stomp_client_sup, Configuration,
+      transport(?TLS_PROTOCOL), rabbit_stomp_client_sup, Configuration,
       'stomp/ssl', NumAcceptors, "STOMP TLS listener").
 
 transport(Protocol) ->
     case Protocol of
-        stomp       -> ranch_tcp;
-        'stomp/ssl' -> ranch_ssl
+        ?TCP_PROTOCOL -> ranch_tcp;
+        ?TLS_PROTOCOL -> ranch_ssl
     end.


### PR DESCRIPTION
This makes the refs predictable and easy to compute
from a listener record. Then suspending all listeners
becomes a lot simpler.

While at it, make protocol applications clean up
their listeners when they stop. This way tests
and other callers that have to stop the app
would not need to know anything about
its listeners.

Part of rabbitmq/rabbitmq-server#2321